### PR TITLE
Fix parsing of lowercase location

### DIFF
--- a/lib/page.ex
+++ b/lib/page.ex
@@ -49,7 +49,7 @@ defmodule Page do
     {_, location} =
       headers 
       |> Enum.find(
-        (fn(item) -> item |> Tuple.to_list |> Enum.member?("Location") end)
+        (fn {key, _val} -> String.downcase(key) == "location" end)
       )
     location
   end


### PR DESCRIPTION
For some reason some http proxy returns location header as
lowercase instead of the usual Location. Bonus points if you
have a cache in front of your proxy so some the capitalization
may be random :)
Fixes crawling of dev.welaika.com. Or other firebase sites.